### PR TITLE
Fix #15 - Perfection score for items with ac%

### DIFF
--- a/src/scripts/items/comparison/perfectionScore.ts
+++ b/src/scripts/items/comparison/perfectionScore.ts
@@ -72,7 +72,10 @@ export function perfectionScore(item: Item) {
     if (min === max) {
       return;
     }
-    score = (nbProps * score + (value - min) / (max - min)) / ++nbProps;
+    // % enhanced defense armor always spawn with max def + 1
+    score =
+      (nbProps * score + (Math.min(value, max) - min) / (max - min)) /
+      ++nbProps;
   }
 
   for (const range of ranges) {
@@ -98,11 +101,9 @@ export function perfectionScore(item: Item) {
     });
   }
 
-  // % enhanced defense armor always spawn with max def + 1
   if (
     (item.quality === ItemQuality.UNIQUE || item.quality === ItemQuality.SET) &&
-    "def" in base &&
-    !ranges.some(({ prop }) => prop === "ac%")
+    "def" in base
   ) {
     let defense = item.defense ?? 0;
     if (item.ethereal) {

--- a/src/scripts/items/comparison/perfectionScore.ts
+++ b/src/scripts/items/comparison/perfectionScore.ts
@@ -107,7 +107,7 @@ export function perfectionScore(item: Item) {
   ) {
     let defense = item.defense ?? 0;
     if (item.ethereal) {
-      defense = defense / 1.5;
+      defense = Math.round(defense / 1.5);
     }
     addProp(defense, base.def[0], base.def[1]);
   }


### PR DESCRIPTION
As your comment in the code already mentions items with ac% always spawn with base max ac + 1. this leads to a wrong calculation of the perfection score due to the actual ac being higher by 1 than the base item can have