### PR TITLE
Added magical property ranges to the tooltip

### DIFF
--- a/src/scripts/items/comparison/perfectionScore.ts
+++ b/src/scripts/items/comparison/perfectionScore.ts
@@ -1,14 +1,13 @@
 import {
   ModifierRange,
   PROPERTIES,
-  RUNEWORDS,
   SET_ITEMS,
   SKILL_TABS,
-  UNIQUE_ITEMS,
 } from "../../../game-data";
 import { Item } from "../types/Item";
 import { ItemQuality } from "../types/ItemQuality";
 import { getBase } from "../getBase";
+import { getRanges } from "../getRanges";
 import { Modifier } from "../types/Modifier";
 
 function checkRange(
@@ -47,21 +46,7 @@ function checkRange(
 export function perfectionScore(item: Item) {
   if (!item.modifiers) return 0;
 
-  let ranges: ModifierRange[];
-  if (item.runeword) {
-    ranges = RUNEWORDS[item.runewordId!].modifiers;
-  } else if (item.quality === ItemQuality.UNIQUE) {
-    ranges = UNIQUE_ITEMS[item.unique!].modifiers;
-  } else if (item.quality === ItemQuality.SET) {
-    ranges = SET_ITEMS[item.unique!].baseModifiers;
-  } else {
-    throw new Error(
-      "Only uniques, sets and runewords have a perfection score."
-    );
-  }
-  // We ignore the "Extra bloody" prop not to confuse people with hidden imperfections
-  ranges = ranges.filter(({ prop }) => prop !== "bloody");
-
+  const ranges = getRanges(item);
   const base = getBase(item);
 
   // Computing an average incrementally

--- a/src/scripts/items/getRanges.ts
+++ b/src/scripts/items/getRanges.ts
@@ -1,0 +1,19 @@
+import {ModifierRange, RUNEWORDS, SET_ITEMS, UNIQUE_ITEMS} from "../../game-data";
+import {Item} from "./types/Item";
+import {ItemQuality} from "./types/ItemQuality";
+
+export function getRanges(item: Item): ModifierRange[] {
+  let ranges: ModifierRange[] = [];
+  if (item.runeword) {
+    ranges = RUNEWORDS[item.runewordId!].modifiers;
+  } else if (item.quality === ItemQuality.UNIQUE) {
+    ranges = UNIQUE_ITEMS[item.unique!].modifiers;
+  } else if (item.quality === ItemQuality.SET) {
+    ranges = SET_ITEMS[item.unique!].baseModifiers;
+  } else {
+    return ranges;
+  }
+  // We ignore the "Extra bloody" prop not to confuse people with hidden imperfections
+  ranges = ranges.filter(({prop}) => prop !== "bloody");
+  return ranges;
+}

--- a/src/web/stash/ItemTooltip.tsx
+++ b/src/web/stash/ItemTooltip.tsx
@@ -1,8 +1,10 @@
 import { Item } from "../../scripts/items/types/Item";
 import "./ItemTooltip.css";
 import { getBase } from "../../scripts/items/getBase";
+import { getRanges } from "../../scripts/items/getRanges";
 import { colorClass } from "./utils/colorClass";
 import { useState } from "preact/hooks";
+import { PROPERTIES } from "../../game-data";
 
 let UNIQUE_ID = 0;
 
@@ -14,18 +16,37 @@ export function ItemTooltip({ item }: { item: Item }) {
     return <span class={className}>{item.name}</span>;
   }
 
+  const rangeMap = getRanges(item).reduce(function(map: {[prop: string]: number[]}, range) {
+    if (range.min && range.max && range.min !== range.max && !["levelup-skill", "death-skill"].includes(range.prop)){
+      const { stats } = PROPERTIES[range.prop];
+      for (const { stat } of stats) {
+        map[stat] = [range.min, range.max];
+      }
+    }
+    return map;
+  }, {});
   const base = getBase(item);
+
+  const getRangeDesc = function (stat: string){
+    const range = rangeMap[stat];
+    return range !== undefined ? ` [${range[0]} - ${range[1]}]` : "";
+  }
+
+  const getSocketsRangeDesc = function (){
+    const range = rangeMap["item_numsockets"];
+    return range !== undefined ? ` [${range[0]} - ${Math.min(range[1]!, base.maxSockets)}]` : "";
+  }
 
   const magicMods =
     item.modifiers?.map(
-      ({ description }) => description && <div class="magic">{description}</div>
+      ({ stat, description }) => description && <div class="magic">{description} <span class="socketed">{getRangeDesc(stat)}</span></div>
     ) ?? [];
   if (item.ethereal || item.sockets) {
     const toDisplay = [
       item.ethereal && "Ethereal",
       item.sockets && `Socketed (${item.sockets})`,
     ].filter((m) => !!m);
-    magicMods?.push(<div class="magic">{toDisplay.join(", ")}</div>);
+    magicMods?.push(<div class="magic">{toDisplay.join(", ")}<span class="socketed">{getSocketsRangeDesc()}</span></div>);
   }
 
   const setItemMods = item.setItemModifiers?.flatMap((mods) =>
@@ -60,6 +81,9 @@ export function ItemTooltip({ item }: { item: Item }) {
             Defense:{" "}
             <span class={item.enhancedDefense ? "magic" : ""}>
               {item.defense}
+              <span class="socketed">
+                {" "}[{base["def"][0]} - {base["def"][1]}]
+              </span>
             </span>
           </div>
         )}

--- a/src/web/stash/ItemTooltip.tsx
+++ b/src/web/stash/ItemTooltip.tsx
@@ -16,8 +16,17 @@ export function ItemTooltip({ item }: { item: Item }) {
     return <span class={className}>{item.name}</span>;
   }
 
-  const rangeMap = getRanges(item).reduce(function(map: {[prop: string]: number[]}, range) {
-    if (range.min && range.max && range.min !== range.max && !["levelup-skill", "death-skill"].includes(range.prop)){
+  const rangeMap = getRanges(item).reduce(function (
+    map: { [prop: string]: number[] },
+    range
+  ) {
+    if (
+      range.min &&
+      range.max &&
+      range.min !== range.max &&
+      !range.prop.endsWith("-skill") &&
+      !["skill-rand", "charged"].includes(range.prop)
+    ) {
       const { stats } = PROPERTIES[range.prop];
       for (const { stat } of stats) {
         map[stat] = [range.min, range.max];
@@ -27,7 +36,13 @@ export function ItemTooltip({ item }: { item: Item }) {
   }, {});
   const base = getBase(item);
 
-  const getRangeDesc = function (stat: string){
+  const getRangeDesc = function (stat: string) {
+    if (stat === "group:enhanced-dmg"){
+      stat = [
+        "item_mindamage_percent",
+        "item_maxdamage_percent"
+      ].find(x => rangeMap[x] !== undefined) || "";
+    }
     const range = rangeMap[stat];
     return range !== undefined ? ` [${range[0]} - ${range[1]}]` : "";
   }


### PR DESCRIPTION
This PR adds the ranges of variable properties to the end of their line:

![image](https://user-images.githubusercontent.com/1343751/128906348-dc4460b2-54c0-41df-bf54-26ce708c60f8.png)

This also works for variable socket numbers:
![image](https://user-images.githubusercontent.com/1343751/128906394-a23c9253-7d24-456b-a842-ad5997d801eb.png)

Please forgive the crude implementation with lots of `!== undefined` checks. I think there should be a much nicer way to do this (with question marks and whatnot), but I'm absolutely no JS developer and I'm looking forward to suggestions on how to improve my code!

PS: @youdz are you still working on this project? It's been over two weeks since your last activity 😇 