### PR TITLE
Fix Standard of Heroes bug

### DIFF
--- a/src/scripts/items/parsing/parseQuality.ts
+++ b/src/scripts/items/parsing/parseQuality.ts
@@ -60,7 +60,7 @@ export function parseQuality(
       break;
     case ItemQuality.UNIQUE:
       item.unique = readInt(12);
-      item.name = UNIQUE_ITEMS[item.unique].name;
+      item.code === "std" ? item.name = getBase(item).name : item.name = UNIQUE_ITEMS[item.unique].name;
       break;
     case ItemQuality.RARE:
     case ItemQuality.CRAFTED:

--- a/src/scripts/items/post-processing/postProcessItem.ts
+++ b/src/scripts/items/post-processing/postProcessItem.ts
@@ -9,6 +9,7 @@ import { addSetMods } from "./addSetModifiers";
 export function postProcessItem(item: Item) {
   if (
     item.runeword ||
+    item.code !== "std" &&
     item.quality === ItemQuality.UNIQUE ||
     item.quality === ItemQuality.SET
   ) {

--- a/src/web/items/AdditionalInfo.tsx
+++ b/src/web/items/AdditionalInfo.tsx
@@ -17,6 +17,7 @@ export function AdditionalInfo({ item, quantity }: AdditionalInfoProps) {
 
   if (
     item.runeword ||
+    item.code !== "std" &&
     item.quality === ItemQuality.UNIQUE ||
     item.quality === ItemQuality.SET
   ) {


### PR DESCRIPTION
I think I understand what was causing the Standard of Heroes bug. It's because it is a unique item (rarity 4 in Misc.txt) that is not listed in UniqueItems.txt.
It also ends up with item.unique set to 4095 (possibly due to Standard of Heroes being 4 bytes shorter than other items) and there is no UNIQUE_ITEMS[4095] to get the item name from.
I found a solution that works but adds an extra check to three different files. I feel like there must be a cleaner and more efficient solution, especially given how simple the problem is.